### PR TITLE
Tests for array declarations and duplicate record fields

### DIFF
--- a/tests/00_typechecking/00_errors/03_arrays/022_array_decl.zi
+++ b/tests/00_typechecking/00_errors/03_arrays/022_array_decl.zi
@@ -1,0 +1,7 @@
+test()
+{
+    a:int[][5][7];
+    a[0] = 7;
+}
+//@PRACOWNIA
+//@should_not_typecheck

--- a/tests/00_typechecking/00_errors/12_records/03_duplicate_fields.zi
+++ b/tests/00_typechecking/00_errors/12_records/03_duplicate_fields.zi
@@ -1,0 +1,4 @@
+foo(r:{x:int, x:int}) {}
+
+//@PRACOWNIA
+//@should_not_typecheck

--- a/tests/00_typechecking/01_ok/00_basic/116_array_decl.zi
+++ b/tests/00_typechecking/01_ok/00_basic/116_array_decl.zi
@@ -1,0 +1,14 @@
+test()
+{
+  xs:int[][5][7];
+  xs[0][1][2] = 7;
+  xs[0][2] = {};
+  xs[0] = {{}, {}};
+
+  a:int[][][] = xs;
+  b:int[][] = xs[1]
+  c:int[] = xs[1][2];
+  d:int = xs[1][2][3];
+}
+//@PRACOWNIA
+//@stop_after typechecker


### PR DESCRIPTION
`022_array_decl.zi` and `116_array_decl.zi` tests check whether array declarations have correct types.
`03_duplicate_fields.zi` test ensures that duplicated record fields are not allowed.